### PR TITLE
Initial tests for stemma.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
                ubuntu-clang-15,
                macos-xcode-14-intel,
                macos-xcode-14-arm,
-#               windows
+               windows
                ]
 
         include:
@@ -58,11 +58,11 @@ jobs:
             version: "14"
             arch: "mac-arm64"
 
-#          - name: windows
-#            os: ubuntu-22.04
-#            compiler: mingw
-#            version: "N/A"
-#            arch: "win64"
+          - name: windows
+            os: ubuntu-22.04
+            compiler: mingw
+            version: "N/A"
+            arch: "win64"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,154 @@
+name: Build and test
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+    - "*"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        name: [ubuntu-gcc-10,
+               ubuntu-gcc-11,
+               ubuntu-gcc-12,
+               ubuntu-clang-15,
+               macos-xcode-14-intel,
+               macos-xcode-14-arm,
+#               windows
+               ]
+
+        include:
+          - name: ubuntu-gcc-10
+            os: ubuntu-20.04
+            compiler: gcc
+            version: "10"
+            arch: "linux64"
+
+          - name: ubuntu-gcc-11
+            os: ubuntu-22.04
+            compiler: gcc
+            version: "11"
+            arch: "linux64"
+
+          - name: ubuntu-gcc-12
+            os: ubuntu-22.04
+            compiler: gcc
+            version: "12"
+            arch: "linux64"
+
+          - name: ubuntu-clang-15
+            os: ubuntu-22.04
+            compiler: clang
+            version: "15"
+            arch: "linux64"
+
+          - name: macos-xcode-14-intel
+            os: macos-12
+            compiler: xcode
+            version: "14"
+            arch: "mac-intel64"
+
+          - name: macos-xcode-14-arm
+            os: macos-14
+            compiler: xcode
+            version: "14"
+            arch: "mac-arm64"
+
+#          - name: windows
+#            os: ubuntu-22.04
+#            compiler: mingw
+#            version: "N/A"
+#            arch: "win64"
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.12.0
+
+    - name: Install (Linux)
+      if: runner.os == 'Linux' && matrix.name != 'windows'
+      run: |
+        sudo apt-get install -y ccache
+
+        if [ "${{ matrix.compiler }}" = "gcc" ]; then
+          # For newer GCCs, maybe.
+          # sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
+          # sudo apt-get update
+
+          sudo apt-get install -y g++-${{ matrix.version }}
+          echo "CC=ccache gcc-${{ matrix.version }}" >> $GITHUB_ENV
+        else
+          sudo apt-get install -y clang-${{ matrix.version }}
+          echo "CC=ccache clang-${{ matrix.version }}" >> $GITHUB_ENV
+        fi
+
+    - name: Install (Linux -> Windows [cross])
+      if: matrix.name == 'windows'
+      run: |
+        # For mingw/gcc-12.
+        cat /etc/apt/sources.list
+        sudo sed -i 's/jammy/lunar/g' /etc/apt/sources.list
+
+        sudo apt-get update
+        sudo apt-get install -y cmake ninja-build ccache pkg-config
+        sudo apt-get install -y dos2unix g++-mingw-w64 mingw-w64-tools wine64 zstd
+
+        echo "CC=ccache x86_64-w64-mingw32-gcc" >> $GITHUB_ENV
+
+    - name: Select XCode version (macOS)
+      if: runner.os == 'macOS'
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ matrix.version }}
+
+    - name: Install (macOS)
+      if: runner.os == 'macOS'
+      run: |
+          brew install cmake ninja pkg-config ccache coreutils
+          echo "CC=ccache clang" >> $GITHUB_ENV
+
+    # Caches for different branches are isolated, so we don't need to put the branch name into the key.
+    # The total size for all caches in a repository is 5Gb.
+
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      run: |
+        ccache --set-config=cache_dir=$HOME/.ccache
+
+        if [ "${{ runner.os }}" = "Linux" ]; then
+          stamp=$(date '+%s')
+        else
+          stamp=$(gdate '+%s')
+        fi
+        echo "${stamp}"
+        echo "timestamp=${stamp}" >> $GITHUB_OUTPUT
+
+    - name: ccache cache files
+#      uses: actions/cache@v2
+      uses: pat-s/always-upload-cache@v3.0.11
+      with:
+         path: ~/.ccache
+         key: ${{ matrix.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+         restore-keys: |
+           ${{ matrix.name }}-ccache-
+
+    - name: Build
+      run: |
+        mkdir $HOME/bin
+        make
+
+#    - name: Test
+#      if: matrix.name != 'windows'
+#      run: |
+#        ./stemma
+
+#    - name: Test
+#      if: matrix.name == 'windows'
+#      run: |
+#        wine ./stemma


### PR DESCRIPTION
This PR adds some basic Github Actions tests for stemma.  The idea is to automatically run tests on any uploaded changes.  It is also possible to use Github Actions to automatically compile and upload executables for Linux/Windows/Mac when you make a new release, but I didn't include that here.

The tests are pretty basic, but should serve as a template that can be expanded.  Currently it tests any changes on Linux and Mac, with gcc and clang, and for Intel and Arm64 (on Mac).  Windows tests actually run on Linux using a cross-compiler, but they are commented out because there is a compilation issue on windows.  Tests that run the compiled executable are also commented out because it (sensibly) returns a non-zero exit code when it is not given any input files.

Currently it seems that stemma doesn't build on windows.  The issue seems to be that on Windows `long int` has size 4, and `long long int` has size 8, whereas on Linux and Mac `long int` has size 8.
```
net.c: In function ‘ntDiffLinks’:
net.c:837:20: error: duplicate case value
  837 | switch (0) case 0: case (ALIGN - 3): ;  // Make sure the word size is not 4.
      |                    ^~~~
net.c:837:12: note: previously used here
  837 | switch (0) case 0: case (ALIGN - 3): ;  // Make sure the word size is not 4.
      |            ^~~~
```
You can run this yourself on Linux by installing the cross-compiler mingw (as shown in the template) and running `CC=x86_64-w64-mingw32-gcc make`.

There are a few warnings in the build logs that might be interesting.  See https://github.com/bredelings/stemma/actions.  Here's one for clang-15 on Linux:

```
heur.c:272:19: warning: implicit conversion from 'double' to 'int' changes value from 0.5 to 0 [-Wliteral-conversion]
                                temperature = 0.5;
                                            ~ ^~~
```
